### PR TITLE
Fix price bug from orders

### DIFF
--- a/controllers/order.js
+++ b/controllers/order.js
@@ -35,7 +35,7 @@ export const createOrder = async (req, res) => {
             const items = line_items.data;
             const address = session.collected_information.shipping_details.address;
             const paymentType = session.payment_method_types[0];
-            const itemsPrice = session.amount_subtotal;
+            const itemsPrice = session.amount_subtotal / 100;
             const taxPrice = session.total_details.amount_tax;
             const shippingPrice = session.total_details.amount_shipping;
             const isPaid = session.payment_status === 'paid' ? true : false;


### PR DESCRIPTION
Visually the price was correct, but when sent to stripe, the price was two zeros more e.g. 1 -> 100.

Fixed pricing on what gets sent to the database.